### PR TITLE
fix support for snowflake json extract

### DIFF
--- a/macros/activity_schema/dataset/select_column.sql
+++ b/macros/activity_schema/dataset/select_column.sql
@@ -48,3 +48,7 @@ json_extract_path_text({{ json_col }}, {{dbt.string_literal(key) }})
 {% macro bigquery__json_extract(json_col, key) -%}
 json_extract({{ json_col }}, {{dbt.string_literal("$."~key) }})
 {%- endmacro %}
+
+{%- macro snowflake__json_extract(json_col, key) -%}
+to_varchar(get_path({{json_col}}, '{{key}}'))
+{%- endmacro -%}


### PR DESCRIPTION
This PR:
* adds a Snowflake-specific implementation of the `json_extract` macro for the package to accommodate how the package bundles up the json object in the `build_activity` macro in activity models.
