### PR TITLE
Hotfixes 0.1.3

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "dbt_aql"
-version: "0.1.0"
+version: "0.1.3"
 
 config-version: 2
 

--- a/integration_tests/models/datasets/aql_syntax/dataset__joined.sql
+++ b/integration_tests/models/datasets/aql_syntax/dataset__joined.sql
@@ -1,0 +1,20 @@
+{% set aql %}
+using customer_stream
+select first visited_page (
+    activity_id as activity_id,
+    entity_uuid as customer_id,
+    ts as first_visited_google_at
+    filter {{dbt_aql.json_extract('{feature_json}', 'referrer_url')}} = 'google.com'
+)
+aggregate after bought_something (
+    count(activity_id) as total_large_purchases_after
+    join nullif({{dbt_aql.json_extract('{joined}.{feature_json}', 'total_sales')}}, '')::int > 100
+)
+include (
+    total_items_purchased_after
+)
+{% endset %}
+
+-- depends_on: {{ ref('output__joined') }}
+
+{{ dbt_aql.dataset(aql) }}

--- a/integration_tests/models/datasets/aql_syntax/schema.yml
+++ b/integration_tests/models/datasets/aql_syntax/schema.yml
@@ -7,3 +7,10 @@ models:
     tests:
       - dbt_utils.equality:
           compare_model: ref("output__filtered")
+
+  - name: dataset__joined
+    description: A test to validate the functionality of join clauses in aql.
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref("output__joined")
+

--- a/integration_tests/seeds/datasets/aql_syntax/output__joined.csv
+++ b/integration_tests/seeds/datasets/aql_syntax/output__joined.csv
@@ -1,0 +1,4 @@
+activity_id,customer_id,first_visited_google_at,total_large_purchases_after,total_items_purchased_after
+e58cfb189af4fbf30f22821af7aa9316,1,2022-01-01 22:10:11,2,11
+fdf62f7ddcd69fc3c3dbd54bf7a34452,7,2022-04-13 22:10:11,0,0
+d5d41e942d4b0b5325741007e8814f00,10,2022-01-13 22:10:11,2,18

--- a/macros/aql/parse.sql
+++ b/macros/aql/parse.sql
@@ -320,7 +320,7 @@ be wrapped in a valid aggregation function.
 {% macro _parse_filters(query) %}
 {%- set ws = dbt_aql.whitespace() -%}
 {%- set ws_join = ws~"join"~ws -%}
-{%- set query_stripped = query.strip() -%}
+{%- set query_stripped = ' '~query.strip() -%}
 
 {%- set join_ixs = modules.re.search(ws_join, query_stripped) -%}
 {%- if join_ixs is not none -%}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-aql"
-version = "0.1.0"
+version = "0.1.3"
 description = "A dbt package to query Activity Streams using a SQL-esque interface."
 authors = ["Bryce Codell <bryce.codell@24analytics.co"]
 license = "GNU"


### PR DESCRIPTION
This PR:
* fixes parsing functionality to make sure extra join conditions are properly captured
* makes an improvement to dataset query functionality for filtered joined activities, where only `append` joined activities get pre-filtered in a separate CTE, while `aggregate` joined activities get filtered in the existing CTE. This is because only `append` activities rely on `activity_occurrence/repeated_at` columns, which need to be recomputed for filtered activities (which is costly)
* adds testing for a dataset that uses extra join conditions
