### PR TITLE
hotfix bigquery json extract

### DIFF
--- a/macros/activity_schema/dataset/select_column.sql
+++ b/macros/activity_schema/dataset/select_column.sql
@@ -46,7 +46,7 @@ json_extract_path_text({{ json_col }}, {{dbt.string_literal(key) }})
 {%- endmacro %}
 
 {% macro bigquery__json_extract(json_col, key) -%}
-json_extract({{ json_col }}, {{dbt.string_literal("$."~key) }})
+string(json_extract({{ json_col }}, {{dbt.string_literal("$."~key) }}))
 {%- endmacro %}
 
 {%- macro snowflake__json_extract(json_col, key) -%}


### PR DESCRIPTION
wrap with bq's `string` function