### PR TITLE
Fix/split part compatibility tony

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-
+logs/

--- a/macros/activity_schema/dataset/aggregations/first_value.sql
+++ b/macros/activity_schema/dataset/aggregations/first_value.sql
@@ -20,7 +20,7 @@ cast(split_part(
 {% macro bigquery__aggfunc_first_value(column) %}
 {%- set joined = dbt_aql.joined() -%}
 {%- set ts = dbt_aql.schema_columns().ts -%}
-{%- set delimiter = ")" -%}
+{%- set delimiter = ";.,;" -%}
 cast(
     {{ dbt.split_part(
         string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ dbt.string_literal(delimiter) ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',

--- a/macros/activity_schema/dataset/aggregations/first_value.sql
+++ b/macros/activity_schema/dataset/aggregations/first_value.sql
@@ -23,7 +23,7 @@ cast(split_part(
 {%- set delimiter = ";.,;" -%}
 cast(
     {{ dbt.split_part(
-        string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ dbt.string_literal(delimiter) ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',
+        string_text='cast(' || joined || '.' || ts || ' as ' || dbt.type_string() || ')' || dbt.string_literal(delimiter) || 'cast(' || column.column_sql || ' as ' || dbt.type_string() || ')',
         delimiter_text=dbt.string_literal(delimiter),
         part_number=2
     ) }}

--- a/macros/activity_schema/dataset/aggregations/first_value.sql
+++ b/macros/activity_schema/dataset/aggregations/first_value.sql
@@ -6,6 +6,21 @@
 {%- set joined = dbt_aql.joined() -%}
 {%- set ts = dbt_aql.schema_columns().ts -%}
 {%- set delimiter = ";.,;" -%}
+cast(split_part(
+            min(
+                cast({{joined}}.{{ts}} as {{dbt.type_string()}})
+                || {{dbt.string_literal(delimiter)}}
+                || cast({{ column.column_sql }} as {{dbt.type_string()}})
+            ),
+            {{dbt.string_literal(delimiter)}},
+            2
+        ) as {{column.data_type}})
+{%- endmacro -%}
+
+{% macro bigquery__aggfunc_first_value(column) %}
+{%- set joined = dbt_aql.joined() -%}
+{%- set ts = dbt_aql.schema_columns().ts -%}
+{%- set delimiter = ")" -%}
 cast(
     {{ dbt.split_part(
         string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ dbt.string_literal(delimiter) ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',

--- a/macros/activity_schema/dataset/aggregations/first_value.sql
+++ b/macros/activity_schema/dataset/aggregations/first_value.sql
@@ -8,7 +8,7 @@
 {%- set delimiter = ";.,;" -%}
 cast(
     {{ dbt.split_part(
-        string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' || dbt.string_literal(delimiter) || 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',
+        string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ dbt.string_literal(delimiter) ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',
         delimiter_text=dbt.string_literal(delimiter),
         part_number=2
     ) }}

--- a/macros/activity_schema/dataset/aggregations/first_value.sql
+++ b/macros/activity_schema/dataset/aggregations/first_value.sql
@@ -6,15 +6,13 @@
 {%- set joined = dbt_aql.joined() -%}
 {%- set ts = dbt_aql.schema_columns().ts -%}
 {%- set delimiter = ";.,;" -%}
-cast(split_part(
-            min(
-                cast({{joined}}.{{ts}} as {{dbt.type_string()}})
-                || {{dbt.string_literal(delimiter)}}
-                || cast({{ column.column_sql }} as {{dbt.type_string()}})
-            ),
-            {{dbt.string_literal(delimiter)}},
-            2
-        ) as {{column.data_type}})
+cast(
+    {{ dbt.split_part(
+        string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' || dbt.string_literal(delimiter) || 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',
+        delimiter_text=dbt.string_literal(delimiter),
+        part_number=2
+    ) }}
+as {{column.data_type}})
 {%- endmacro -%}
 
 {% macro duckdb__aggfunc_first_value(column) %}

--- a/macros/activity_schema/dataset/aggregations/first_value.sql
+++ b/macros/activity_schema/dataset/aggregations/first_value.sql
@@ -21,14 +21,18 @@ cast(split_part(
 {%- set joined = dbt_aql.joined() -%}
 {%- set ts = dbt_aql.schema_columns().ts -%}
 {%- set delimiter = ";.,;" -%}
+{%- set string_text = 'min(cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ 
+    ' || ' ~ dbt.string_literal(delimiter) ~ 
+    ' || ' ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ '))' -%}
 cast(
     {{ dbt.split_part(
-        string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ ' || ' ~ dbt.string_literal(delimiter) ~ ' || ' ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',
+        string_text=string_text,
         delimiter_text=dbt.string_literal(delimiter),
         part_number=2
     ) }}
 as {{column.data_type}})
 {%- endmacro -%}
+
 
 {% macro duckdb__aggfunc_first_value(column) %}
 {%- set joined = dbt_aql.joined() -%}

--- a/macros/activity_schema/dataset/aggregations/first_value.sql
+++ b/macros/activity_schema/dataset/aggregations/first_value.sql
@@ -23,7 +23,7 @@ cast(split_part(
 {%- set delimiter = ";.,;" -%}
 cast(
     {{ dbt.split_part(
-        string_text='cast(' || joined || '.' || ts || ' as ' || dbt.type_string() || ')' || dbt.string_literal(delimiter) || 'cast(' || column.column_sql || ' as ' || dbt.type_string() || ')',
+        string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ ' || ' ~ dbt.string_literal(delimiter) ~ ' || ' ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',
         delimiter_text=dbt.string_literal(delimiter),
         part_number=2
     ) }}

--- a/macros/activity_schema/dataset/aggregations/last_value.sql
+++ b/macros/activity_schema/dataset/aggregations/last_value.sql
@@ -17,7 +17,7 @@ cast(split_part(
         ) as {{column.data_type}})
 {%- endmacro -%}
 
-{% macro bigquery__aggfunc_first_value(column) %}
+{% macro bigquery__aggfunc_last_value(column) %}
 {%- set joined = dbt_aql.joined() -%}
 {%- set ts = dbt_aql.schema_columns().ts -%}
 {%- set delimiter = ";.,;" -%}

--- a/macros/activity_schema/dataset/aggregations/last_value.sql
+++ b/macros/activity_schema/dataset/aggregations/last_value.sql
@@ -20,7 +20,7 @@ cast(split_part(
 {% macro bigquery__aggfunc_last_value(column) %}
 {%- set joined = dbt_aql.joined() -%}
 {%- set ts = dbt_aql.schema_columns().ts -%}
-{%- set delimiter = ")" -%}
+{%- set delimiter = ";.,;" -%}
 cast(
     {{ dbt.split_part(
         string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ dbt.string_literal(delimiter) ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',

--- a/macros/activity_schema/dataset/aggregations/last_value.sql
+++ b/macros/activity_schema/dataset/aggregations/last_value.sql
@@ -23,7 +23,7 @@ cast(split_part(
 {%- set delimiter = ";.,;" -%}
 cast(
     {{ dbt.split_part(
-        string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ dbt.string_literal(delimiter) ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',
+        string_text='cast(' || joined || '.' || ts || ' as ' || dbt.type_string() || ')' || dbt.string_literal(delimiter) || 'cast(' || column.column_sql || ' as ' || dbt.type_string() || ')',
         delimiter_text=dbt.string_literal(delimiter),
         part_number=2
     ) }}

--- a/macros/activity_schema/dataset/aggregations/last_value.sql
+++ b/macros/activity_schema/dataset/aggregations/last_value.sql
@@ -8,7 +8,7 @@
 {%- set delimiter = ";.,;" -%}
 cast(
     {{ dbt.split_part(
-        string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' || dbt.string_literal(delimiter) || 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',
+        string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ dbt.string_literal(delimiter) ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',
         delimiter_text=dbt.string_literal(delimiter),
         part_number=2
     ) }}

--- a/macros/activity_schema/dataset/aggregations/last_value.sql
+++ b/macros/activity_schema/dataset/aggregations/last_value.sql
@@ -17,13 +17,13 @@ cast(split_part(
         ) as {{column.data_type}})
 {%- endmacro -%}
 
-{% macro bigquery__aggfunc_last_value(column) %}
+{% macro bigquery__aggfunc_first_value(column) %}
 {%- set joined = dbt_aql.joined() -%}
 {%- set ts = dbt_aql.schema_columns().ts -%}
 {%- set delimiter = ";.,;" -%}
 cast(
     {{ dbt.split_part(
-        string_text='cast(' || joined || '.' || ts || ' as ' || dbt.type_string() || ')' || dbt.string_literal(delimiter) || 'cast(' || column.column_sql || ' as ' || dbt.type_string() || ')',
+        string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ ' || ' ~ dbt.string_literal(delimiter) ~ ' || ' ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',
         delimiter_text=dbt.string_literal(delimiter),
         part_number=2
     ) }}

--- a/macros/activity_schema/dataset/aggregations/last_value.sql
+++ b/macros/activity_schema/dataset/aggregations/last_value.sql
@@ -6,15 +6,13 @@
 {%- set joined = dbt_aql.joined() -%}
 {%- set ts = dbt_aql.schema_columns().ts -%}
 {%- set delimiter = ";.,;" -%}
-cast(split_part(
-            max(
-                cast({{joined}}.{{ts}} as {{dbt.type_string()}})
-                || {{dbt.string_literal(delimiter)}}
-                || cast({{ column.column_sql }} as {{dbt.type_string()}})
-            ),
-            {{dbt.string_literal(delimiter)}},
-            2
-        ) as {{column.data_type}})
+cast(
+    {{ dbt.split_part(
+        string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' || dbt.string_literal(delimiter) || 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',
+        delimiter_text=dbt.string_literal(delimiter),
+        part_number=2
+    ) }}
+as {{column.data_type}})
 {%- endmacro -%}
 
 {% macro duckdb__aggfunc_last_value(column) %}

--- a/macros/activity_schema/dataset/aggregations/last_value.sql
+++ b/macros/activity_schema/dataset/aggregations/last_value.sql
@@ -6,6 +6,21 @@
 {%- set joined = dbt_aql.joined() -%}
 {%- set ts = dbt_aql.schema_columns().ts -%}
 {%- set delimiter = ";.,;" -%}
+cast(split_part(
+            max(
+                cast({{joined}}.{{ts}} as {{dbt.type_string()}})
+                || {{dbt.string_literal(delimiter)}}
+                || cast({{ column.column_sql }} as {{dbt.type_string()}})
+            ),
+            {{dbt.string_literal(delimiter)}},
+            2
+        ) as {{column.data_type}})
+{%- endmacro -%}
+
+{% macro bigquery__aggfunc_last_value(column) %}
+{%- set joined = dbt_aql.joined() -%}
+{%- set ts = dbt_aql.schema_columns().ts -%}
+{%- set delimiter = ")" -%}
 cast(
     {{ dbt.split_part(
         string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ dbt.string_literal(delimiter) ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',

--- a/macros/activity_schema/dataset/aggregations/last_value.sql
+++ b/macros/activity_schema/dataset/aggregations/last_value.sql
@@ -21,9 +21,12 @@ cast(split_part(
 {%- set joined = dbt_aql.joined() -%}
 {%- set ts = dbt_aql.schema_columns().ts -%}
 {%- set delimiter = ";.,;" -%}
+{%- set string_text = 'max(cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ 
+    ' || ' ~ dbt.string_literal(delimiter) ~ 
+    ' || ' ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ '))' -%}
 cast(
     {{ dbt.split_part(
-        string_text='cast(' ~ joined ~ '.' ~ ts ~ ' as ' ~ dbt.type_string() ~ ')' ~ ' || ' ~ dbt.string_literal(delimiter) ~ ' || ' ~ 'cast(' ~ column.column_sql ~ ' as ' ~ dbt.type_string() ~ ')',
+        string_text=string_text,
         delimiter_text=dbt.string_literal(delimiter),
         part_number=2
     ) }}


### PR DESCRIPTION
Create a separate BigQuery macro for first and last value aggs. Handles a swap for the use of `dbt.split_part` and adds working concatenation delimiters in the string value.