### PR TITLE
Hotfix - Bigquery Cluster Keys

### DIFF
--- a/integration_tests/.gitignore
+++ b/integration_tests/.gitignore
@@ -3,3 +3,4 @@ tmp
 target
 dbt_packages
 *.json
+package-lock.yml

--- a/integration_tests/models/activities/customer_stream.sql
+++ b/integration_tests/models/activities/customer_stream.sql
@@ -1,4 +1,21 @@
-{{ config(options={"partition_by": dbt_aql.cluster_keys()}) }}
+{% set keys = dbt_aql.cluster_keys() %}
+{% if target.name == 'bigquery' %}
+    {% set cluster_keys = keys.cluster_by %}
+    {% set partition_keys = keys.partition_by %}
+{# TODO: remove snowflake-specific implementation once localstack bugs are fixed #}
+{% elif target.name == 'snowflake' %}
+    {% set cluster_keys = none %}
+    {% set partition_keys = none %}
+{% else %}
+    {% set cluster_keys = keys %}
+    {% set partition_keys = '' %}
+{% endif %}
+
+{{ config(
+    options={"partition_by": cluster_keys},
+    cluster_by=cluster_keys,
+    partition_by=partition_keys
+) }}
 
 {% set activity_list = [
     ref('customer__bought_something'),

--- a/macros/activity_schema/activity/build_activity.sql
+++ b/macros/activity_schema/activity/build_activity.sql
@@ -32,7 +32,9 @@ Accepted values are one of {{accepted_values_str}}, but received '{{nc}}'
 
 
 {%- set columns = dbt_aql.schema_columns() -%}
+{%- if execute -%}
 {%- do columns.update({"customer": dbt_aql.customer_column(stream)}) -%}
+{%- endif -%}
 {%- if dbt_aql.anonymous_customer_column(stream) is not none -%}
     {%- do columns.update({"anonymous_customer_id": dbt_aql.anonymous_customer_column(stream)}) -%}
 {%- endif -%}

--- a/macros/activity_schema/constants/columns.sql
+++ b/macros/activity_schema/constants/columns.sql
@@ -1,18 +1,14 @@
 {% macro customer_column(stream) %}
-{% if execute %}
-    {%- set customer_alias = var("dbt_aql").get("streams").get(stream).get("customer_id_alias", none) -%}
-    {%- if customer_alias is none -%}
-        {%- set error_message -%}
-    Configuration for stream '{{stream}}' does not include required alias for customer ID column.
-    Please add `customer_id_alias` in your dbt_project.yml configuration for stream '{{stream}}'
-        {%- endset -%}
-        {{ exceptions.warn(error_message) }}
-    {%- else -%}
-        {%- do return(customer_alias) -%}
-    {%- endif -%}
-{% else %}
-    {%- do return("customer") -%}
-{% endif %}
+{%- set customer_alias = var("dbt_aql").get("streams", {}).get(stream, {}).get("customer_id_alias", none) -%}
+{%- if customer_alias is none -%}
+    {%- set error_message -%}
+Configuration for stream '{{stream}}' does not include required alias for customer ID column.
+Please add `customer_id_alias` in your dbt_project.yml configuration for stream '{{stream}}'
+    {%- endset -%}
+    {{ exceptions.warn(error_message) }}
+{%- else -%}
+    {%- do return(customer_alias) -%}
+{%- endif -%}
 {% endmacro %}
 
 

--- a/macros/activity_schema/stream/cluster_keys.sql
+++ b/macros/activity_schema/stream/cluster_keys.sql
@@ -27,6 +27,7 @@
 {% macro bigquery__cluster_keys() %}
 {%- set columns = dbt_aql.schema_columns() -%}
 {# assumes that macro is only used in stream models #}
+{%- set stream = model.name -%}
 {%- set cluster_cols = [
     columns.activity,
     columns.activity_occurrence,

--- a/macros/activity_schema/stream/cluster_keys.sql
+++ b/macros/activity_schema/stream/cluster_keys.sql
@@ -26,10 +26,11 @@
 
 {% macro bigquery__cluster_keys() %}
 {%- set columns = dbt_aql.schema_columns() -%}
+{# assumes that macro is only used in stream models #}
 {%- set cluster_cols = [
     columns.activity,
     columns.activity_occurrence,
-    columns.customer
+    dbt_aql.customer_column(stream)
 ] -%}
 {%- set partition_cols = {
       "field": columns.ts,


### PR DESCRIPTION
Resolves #29 

This PR:
* updates the `customer_column` macro to retrieve the metadata outside of the `execute` method
* fixes the `cluster_keys` macro implementation for Bigquery, which was not properly retrieving the stream alias for the `customer` column