### PR TITLE
Feature: Skip Activity Stream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: dbt CI - duckdb - with stream
         run: |
           cd ./integration_tests
-          sed -i '' 's/skip_stream: true/skip_stream: false/' dbt_project.yml
+          sed -i 's/skip_stream: true/skip_stream: false/' dbt_project.yml
           dbt build -x --target duckdb
         env:
           GCP_KEYFILE_PATH: ./gcp_keyfile.json
@@ -42,7 +42,7 @@ jobs:
       - name: dbt CI - duckdb - skip stream
         run: |
           cd ./integration_tests
-          sed -i '' 's/skip_stream: false/skip_stream: true/' dbt_project.yml
+          sed -i 's/skip_stream: false/skip_stream: true/' dbt_project.yml
           dbt build -x --target duckdb
         env:
           GCP_KEYFILE_PATH: ./gcp_keyfile.json
@@ -53,7 +53,7 @@ jobs:
           localstack extensions install localstack-extension-snowflake
           localstack start -d
           cd ./integration_tests
-          sed -i '' 's/skip_stream: true/skip_stream: false/' dbt_project.yml
+          sed -i 's/skip_stream: true/skip_stream: false/' dbt_project.yml
           dbt build -x --target snowflake
         env:
           DBT_PROFILES_DIR: . # Use integration_tests/profiles.yml
@@ -65,7 +65,7 @@ jobs:
           localstack stop
           localstack start -d
           cd ./integration_tests
-          sed -i '' 's/skip_stream: false/skip_stream: true/' dbt_project.yml
+          sed -i 's/skip_stream: false/skip_stream: true/' dbt_project.yml
           dbt build -x --target snowflake
         env:
           DBT_PROFILES_DIR: . # Use integration_tests/profiles.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,25 +31,47 @@ jobs:
         run: |
           cd ./integration_tests
           dbt deps
-      - name: dbt CI - duckdb
+      - name: dbt CI - duckdb - with stream
         run: |
           cd ./integration_tests
+          sed -i '' 's/skip_stream: true/skip_stream: false/' dbt_project.yml
           dbt build -x --target duckdb
         env:
           GCP_KEYFILE_PATH: ./gcp_keyfile.json
           DBT_PROFILES_DIR: . # Use integration_tests/profiles.yml
-      - name: dbt CI - snowflake
-        id: snowflake_ci
+      - name: dbt CI - duckdb - skip stream
+        run: |
+          cd ./integration_tests
+          sed -i '' 's/skip_stream: false/skip_stream: true/' dbt_project.yml
+          dbt build -x --target duckdb
+        env:
+          GCP_KEYFILE_PATH: ./gcp_keyfile.json
+          DBT_PROFILES_DIR: . # Use integration_tests/profiles.yml
+      - name: dbt CI - snowflake - with stream
+        id: snowflake_ci_with_stream
         run: |
           localstack extensions install localstack-extension-snowflake
           localstack start -d
           cd ./integration_tests
+          sed -i '' 's/skip_stream: true/skip_stream: false/' dbt_project.yml
+          dbt build -x --target snowflake
+        env:
+          DBT_PROFILES_DIR: . # Use integration_tests/profiles.yml
+          DEBUG: 1
+
+      - name: dbt CI - snowflake - skip stream
+        id: snowflake_ci_skip_stream
+        run: |
+          localstack stop
+          localstack start -d
+          cd ./integration_tests
+          sed -i '' 's/skip_stream: false/skip_stream: true/' dbt_project.yml
           dbt build -x --target snowflake
         env:
           DBT_PROFILES_DIR: . # Use integration_tests/profiles.yml
           DEBUG: 1
       - name: localstack logs
-        if: failure() && steps.snowflake_ci.outcome == 'failure'
+        if: failure() && (steps.snowflake_ci_with_stream.outcome == 'failure' || steps.snowflake_ci_skip_stream.outcome == 'failure' )
         run: localstack logs
       - name: dbt CI - bigquery
         run: |
@@ -60,5 +82,22 @@ jobs:
         env:
           GCP_KEYFILE_PATH: ./gcp_keyfile.json
           DBT_PROFILES_DIR: . # Use integration_tests/profiles.yml
-
+      - name: dbt CI - bigquery - with stream
+        run: |
+          cd ./integration_tests
+          echo $GCP_KEYFILE > $GCP_KEYFILE_PATH
+          ls -l
+          dbt build -x --target bigquery
+        env:
+          GCP_KEYFILE_PATH: ./gcp_keyfile.json
+          DBT_PROFILES_DIR: . # Use integration_tests/profiles.yml
+      - name: dbt CI - bigquery - skip stream
+        run: |
+          cd ./integration_tests
+          echo $GCP_KEYFILE > $GCP_KEYFILE_PATH
+          ls -l
+          dbt build -x --target bigquery
+        env:
+          GCP_KEYFILE_PATH: ./gcp_keyfile.json
+          DBT_PROFILES_DIR: . # Use integration_tests/profiles.yml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,18 +73,10 @@ jobs:
       - name: localstack logs
         if: failure() && (steps.snowflake_ci_with_stream.outcome == 'failure' || steps.snowflake_ci_skip_stream.outcome == 'failure' )
         run: localstack logs
-      - name: dbt CI - bigquery
-        run: |
-          cd ./integration_tests
-          echo $GCP_KEYFILE > $GCP_KEYFILE_PATH
-          ls -l
-          dbt build -x --target bigquery
-        env:
-          GCP_KEYFILE_PATH: ./gcp_keyfile.json
-          DBT_PROFILES_DIR: . # Use integration_tests/profiles.yml
       - name: dbt CI - bigquery - with stream
         run: |
           cd ./integration_tests
+          sed -i 's/skip_stream: true/skip_stream: false/' dbt_project.yml
           echo $GCP_KEYFILE > $GCP_KEYFILE_PATH
           ls -l
           dbt build -x --target bigquery
@@ -94,6 +86,7 @@ jobs:
       - name: dbt CI - bigquery - skip stream
         run: |
           cd ./integration_tests
+          sed -i 's/skip_stream: false/skip_stream: true/' dbt_project.yml
           echo $GCP_KEYFILE > $GCP_KEYFILE_PATH
           ls -l
           dbt build -x --target bigquery

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -29,6 +29,7 @@ vars:
         feature_json: attributes
     streams:
       customer_stream:
+        skip_stream: false
         customer_id_alias: entity_uuid
         anonymous_customer_id_alias: anonymous_entity_uuid
         model_prefix: customer__

--- a/integration_tests/models/activities/customer__bought_something.sql
+++ b/integration_tests/models/activities/customer__bought_something.sql
@@ -1,4 +1,19 @@
+{% set keys = dbt_aql.cluster_keys(stream='customer_stream') %}
+{% if target.name == 'bigquery' %}
+    {% set cluster_keys = keys.cluster_by %}
+    {% set partition_keys = keys.partition_by %}
+{# TODO: remove snowflake-specific implementation once localstack bugs are fixed #}
+{% elif target.name == 'snowflake' %}
+    {% set cluster_keys = none %}
+    {% set partition_keys = none %}
+{% else %}
+    {% set cluster_keys = keys %}
+    {% set partition_keys = '' %}
+{% endif %}
+
 {{ config(
+    cluster_by=cluster_keys,
+    partition_by=partition_keys,
     data_types={
         'total_sales': dbt.type_int(),
         'total_items_purchased': dbt.type_int(),

--- a/integration_tests/models/activities/customer__signed_up.sql
+++ b/integration_tests/models/activities/customer__signed_up.sql
@@ -1,4 +1,21 @@
-{{ config(stream='customer_stream') }}
+{% set keys = dbt_aql.cluster_keys(stream='customer_stream') %}
+{% if target.name == 'bigquery' %}
+    {% set cluster_keys = keys.cluster_by %}
+    {% set partition_keys = keys.partition_by %}
+{# TODO: remove snowflake-specific implementation once localstack bugs are fixed #}
+{% elif target.name == 'snowflake' %}
+    {% set cluster_keys = none %}
+    {% set partition_keys = none %}
+{% else %}
+    {% set cluster_keys = keys %}
+    {% set partition_keys = '' %}
+{% endif %}
+
+{{ config(
+    cluster_by=cluster_keys,
+    partition_by=partition_keys,
+    stream='customer_stream'
+) }}
 
 with base as (
     select *

--- a/integration_tests/models/activities/customer__visited_page.sql
+++ b/integration_tests/models/activities/customer__visited_page.sql
@@ -1,4 +1,19 @@
+{% set keys = dbt_aql.cluster_keys(stream='customer_stream') %}
+{% if target.name == 'bigquery' %}
+    {% set cluster_keys = keys.cluster_by %}
+    {% set partition_keys = keys.partition_by %}
+{# TODO: remove snowflake-specific implementation once localstack bugs are fixed #}
+{% elif target.name == 'snowflake' %}
+    {% set cluster_keys = none %}
+    {% set partition_keys = none %}
+{% else %}
+    {% set cluster_keys = keys %}
+    {% set partition_keys = '' %}
+{% endif %}
+
 {{ config(
+    cluster_by=cluster_keys,
+    partition_by=partition_keys,
     data_types={
         'referrer_url': dbt.type_string(),
     },

--- a/macros/activity_schema/activity/activity.sql
+++ b/macros/activity_schema/activity/activity.sql
@@ -29,9 +29,17 @@ aql query in model '{{ model.unique_id }}' has invalid syntax. Parsed invalid re
 {%- else -%}
     {%- set relationship_clause = none -%}
 {%- endif -%}
+{%- set model_prefix = dbt_aql.get_model_prefix(stream) -%}
+{%- if modules.re.search(model_prefix, activity_name) is none -%}
+    {%- set model_name = model_prefix~activity_name -%}
+{%- else -%}
+    {%- set model_name = activity_name -%}
+{%- endif -%}
+
 
 {%- do return(namespace(
     name="activity",
+    model_name=model_name,
     verb=verb,
     relationship_selector=relationship_selector,
     join_condition=join_condition,

--- a/macros/activity_schema/dataset/dataset_column/dataset_column.sql
+++ b/macros/activity_schema/dataset/dataset_column/dataset_column.sql
@@ -22,11 +22,22 @@
 {% endmacro %}
 
 {% macro default__dataset_column(aql) %}
+{%- set av = dbt_aql._activity_verbs() -%}
 {%- set query_no_comments = dbt_aql._strip_comments(aql) -%}
 {%- set query_clean = dbt_aql._clean_query(query_no_comments) -%}
 {%- set using, rest = dbt_aql._parse_keyword(query_clean, ["using"]) -%}
 {%- set stream, rest = dbt_aql._parse_stream(rest) -%}
+{%- set activity, rest = dbt_aql._parse_activity(rest, stream, [av.append, av.aggregate]) -%}
 
 -- depends_on: {{ ref(stream) }}
+
+{%- set model_prefix = dbt_aql.get_model_prefix(stream) -%}
+{% if modules.re.search(model_prefix, activity.activity_name) is none %}
+    {% set m = model_prefix~activity.activity_name %}
+-- depends_on: {{ ref(m) }}
+    {% else %}
+-- depends_on: {{ ref(primary_activity.activity_name) }}
+{% endif %}
+
 
 {% endmacro %}

--- a/macros/activity_schema/stream/build_stream.sql
+++ b/macros/activity_schema/stream/build_stream.sql
@@ -9,11 +9,25 @@
 {{"-- depends_on: "~activity}}
 {% endfor %}
 
+{%- set skip_stream = var("dbt_aql").get("streams", {}).get(model.name, {}).get("skip_stream", false) | as_bool -%}
+
+{%- set columns = dbt_aql.schema_columns() -%}
+{%- set schema_column_types = dbt_aql.schema_column_types() -%}
+
+{%- do columns.update({"customer": dbt_aql.customer_column(model.name)}) -%}
+{%- if dbt_aql.anonymous_customer_column(stream) is not none -%}
+    {%- do columns.update({"anonymous_customer_id": dbt_aql.anonymous_customer_column(model.name)}) -%}
+{%- endif -%}
+{%- set anonymous = dbt_aql.anonymous_customer_column(model.name) -%}
+{%- if anonymous is not none -%}
+    {%- do columns.update({"anonymous_customer_id": anonymous}) -%}
+{%- endif -%}
+
+{% if not skip_stream %}
 {% for activity in activity_list %}
 select *
 from {{activity}}
 {% if is_incremental() %}
-{% set columns = dbt_aql.schema_columns() %}
 where {{columns.ts}} > (select coalesce(max({{columns.ts}}), {{dbt.safe_cast(dbt.string_literal('0001-01-01'), dbt.type_timestamp())}}) from {{this}} where {{columns.activity}} = {{dbt_aql.clean_activity_name(model.name, activity.name)}})
 {% endif %}
 {% if not loop.last %}
@@ -21,5 +35,10 @@ union all
 {% endif %}
 {% endfor %}
 
-
+{% else %}
+select
+    {% for key in columns.keys() %}
+    {% if not loop.first %}, {% endif %} cast(null as {{schema_column_types.get(key, type_string())}}) as {{columns.get(key)}}
+    {% endfor %}
+{% endif %}
 {% endmacro %}

--- a/macros/activity_schema/stream/cluster_keys.sql
+++ b/macros/activity_schema/stream/cluster_keys.sql
@@ -1,8 +1,8 @@
-{% macro cluster_keys() %}
-    {{ return(adapter.dispatch('cluster_keys', 'dbt_aql')()) }}
+{% macro cluster_keys(stream=none) %}
+    {{ return(adapter.dispatch('cluster_keys', 'dbt_aql')(stream)) }}
 {% endmacro %}
 
-{% macro default__cluster_keys() %}
+{% macro default__cluster_keys(stream=none) %}
 {%- set columns = dbt_aql.schema_columns() -%}
 {%- set cluster_cols = [
     columns.activity,
@@ -13,26 +13,54 @@
 {%- do return(cluster_cols) -%}
 {% endmacro %}
 
-{% macro snowflake__cluster_keys() %}
+{% macro snowflake__cluster_keys(stream=none) %}
+{%- set streams = var("dbt_aql").get("streams", {}).keys() -%}
 {%- set columns = dbt_aql.schema_columns() -%}
+
+{%- if model.name in streams -%}
 {%- set cluster_cols = [
     columns.activity,
     columns.activity_occurrence~" in (1, null)",
     columns.activity_repeated_at~" is null",
     "to_date("~columns.ts~")"
 ] -%}
+{%- else -%}
+{%- set cluster_cols = [
+    columns.activity_occurrence~" in (1, null)",
+    columns.activity_repeated_at~" is null",
+    "to_date("~columns.ts~")"
+] -%}
+{%- endif -%}
 {%- do return(cluster_cols) -%}
 {% endmacro %}
 
-{% macro bigquery__cluster_keys() %}
+{% macro bigquery__cluster_keys(stream=none) %}
 {%- set columns = dbt_aql.schema_columns() -%}
-{# assumes that macro is only used in stream models #}
-{%- set stream = model.name -%}
+{%- set streams = var("dbt_aql").get("streams", {}).keys() -%}
+
+{# throw error if no stream passed as input and model name is not a stream #}
+{%- if model.name not in streams and stream == none -%}
+    {% set error_message %}
+Macro 'cluster_keys' is missing the input 'stream' in model '{{ model.unique_id }}'.
+It appears that the macro is being used in an activity model, and Bigquery projects
+that use the one table per activity implementation require the stream to be explicitly
+passed to the 'cluster_keys' macro in each activity model.
+    {% endset %}
+    {{ exceptions.raise_compiler_error(error_message) }}
+{%- elif model.name in streams -%}
+{# cluster stream #}
 {%- set cluster_cols = [
     columns.activity,
     columns.activity_occurrence,
+    dbt_aql.customer_column(model.name)
+] -%}
+{%- else -%}
+{# cluster activity #}
+{%- set cluster_cols = [
+    columns.activity_occurrence,
     dbt_aql.customer_column(stream)
 ] -%}
+{%- endif -%}
 {%- set partition_cols = {
       "field": columns.ts,
       "data_type": "timestamp",
@@ -41,24 +69,43 @@
 {%- do return({"cluster_by": cluster_cols, "partition_by": partition_cols}) -%}
 {% endmacro %}
 
-{% macro redshift__cluster_keys() %}
+{% macro redshift__cluster_keys(stream=none) %}
+{%- set streams = var("dbt_aql").get("streams", {}).keys() -%}
 {%- set columns = dbt_aql.schema_columns() -%}
+
+{%- if model.name in streams -%}
 {%- set cluster_cols = [
     columns.activity,
     columns.ts,
     columns.activity_occurrence
 ] -%}
+{%- else -%}
+{%- set cluster_cols = [
+    columns.ts,
+    columns.activity_occurrence
+] -%}
+{%- endif -%}
 {%- do return({"sort": cluster_cols, "dist": "even"}) -%}
 {% endmacro %}
 
 
-{% macro duckdb__cluster_keys() %}
+{% macro duckdb__cluster_keys(stream=none) %}
+{%- set streams = var("dbt_aql").get("streams", {}).keys() -%}
 {%- set columns = dbt_aql.schema_columns() -%}
+
+{%- if model.name in streams -%}
 {%- set cluster_cols = [
     columns.activity,
     columns.activity_occurrence~" in (1, null)",
     columns.activity_repeated_at~" is null",
     "to_date("~columns.ts~")"
 ] -%}
+{%- else -%}
+{%- set cluster_cols = [
+    columns.activity_occurrence~" in (1, null)",
+    columns.activity_repeated_at~" is null",
+    "to_date("~columns.ts~")"
+] -%}
+{%- endif -%}
 {%- do return(cluster_cols|join(", ")) -%}
 {% endmacro %}


### PR DESCRIPTION
Resolves #31 
Resolves #36 

This PR:
* adds support to configure skipping activity streams in a given activity schema pipeline, including:
  * new optional config parameter in `dbt_project.yml`
  * expands support for `cluster_keys` macro to be used in streams and activity models
  * updates the `build_activity` macro to build an empty table when `skip_stream` is true for the corresponding activity schema
  * updates the `dataset` macro to select from activity models rather than the strem when `skip_stream` is true for the corresponding activity schema