### PR TITLE
docs: README updates for poetry changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,8 +852,8 @@ For developers who would like to contribute to this project, follow the instruct
 1. Fork the repository and clone the forked version
 2. Install poetry ([official installer](https://python-poetry.org/docs/#installing-with-the-official-installer) - version 1.6.1 is recommended as that is what is used in CI)
 3. Set the repo as the working directory
-4. Run `poetry init` to install dependencies
-5. Activate a virtual environment if not activated by default from previous step (`poetry shell`)
+4. Run `poetry install` to install dependencies
+5. Activate a virtual environment if not activated by default from previous step (`poetry env activate`)
 6. Set the working directory to `dbt-activity-schema/integration_tests` and run `dbt deps`
 
 ### Postgres Setup


### PR DESCRIPTION
Poetry updates - `poetry install` instead of `init`. `poetry shell` appears to be `poetry env activate`