### PR TITLE
fix(redshift): handle boolean fields and quoted text in build_json

### DIFF
--- a/integration_tests/models/activities/customer__redshift_edge_cases.sql
+++ b/integration_tests/models/activities/customer__redshift_edge_cases.sql
@@ -1,0 +1,18 @@
+{{
+    config(
+        enabled=target.name == 'redshift',
+        tags=['redshift'],
+        stream='customer_stream',
+        data_types={
+            'text_with_quotes': dbt.type_string(),
+            'text_with_backslash': dbt.type_string(),
+            'is_flagged': dbt_activity_schema.type_boolean(),
+        }
+    )
+}}
+
+with base as (
+    select *
+    from {{ ref('redshift_edge_cases_source') }}
+)
+{{ dbt_activity_schema.build_activity('base', null_columns=['anonymous_customer_id', 'revenue_impact', 'link']) }}

--- a/integration_tests/models/datasets/redshift/dataset__redshift_edge_cases.sql
+++ b/integration_tests/models/datasets/redshift/dataset__redshift_edge_cases.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        enabled=target.name == 'redshift',
+        tags=['redshift']
+    )
+}}
+
+-- Tests that build_activity (fixed redshift__build_json) correctly stores and
+-- retrieves text fields containing quotes/backslashes and boolean fields.
+-- Run on Redshift: dbt build --select tag:redshift
+
+-- depends_on: {{ ref('output__redshift_edge_cases') }}
+
+select
+    CAST({{ dbt_activity_schema.schema_columns('customer_stream').customer }} AS varchar) as customer_id,
+    CAST(attributes.text_with_quotes AS varchar) as text_with_quotes,
+    CAST(attributes.text_with_backslash AS varchar) as text_with_backslash,
+    CAST(attributes.is_flagged AS varchar) as is_flagged
+from {{ ref('customer__redshift_edge_cases') }}
+order by customer_id

--- a/integration_tests/models/datasets/redshift/schema.yml
+++ b/integration_tests/models/datasets/redshift/schema.yml
@@ -1,0 +1,14 @@
+version: 2
+
+# Redshift-only tests. Run with: dbt build --select tag:redshift
+# These models are disabled (config enabled=false) on non-Redshift targets.
+
+models:
+
+  - name: dataset__redshift_edge_cases
+    description: >
+      Validates that build_activity (fixed redshift__build_json) correctly
+      handles text fields containing quotes and backslashes, and boolean fields.
+    data_tests:
+      - dbt_utils.equality:
+          compare_model: ref("output__redshift_edge_cases")

--- a/integration_tests/seeds/activities/redshift_edge_cases_source.csv
+++ b/integration_tests/seeds/activities/redshift_edge_cases_source.csv
@@ -1,0 +1,3 @@
+ts,entity_uuid,text_with_quotes,text_with_backslash,is_flagged
+2022-01-01 00:00:00,1,"say ""hello""",path\to\file,true
+2022-01-02 00:00:00,2,plain text,normal text,false

--- a/integration_tests/seeds/activities/seed_schema.yml
+++ b/integration_tests/seeds/activities/seed_schema.yml
@@ -1,0 +1,7 @@
+version: 2
+
+seeds:
+  - name: redshift_edge_cases_source
+    config:
+      column_types:
+        is_flagged: boolean

--- a/integration_tests/seeds/datasets/redshift/output__redshift_edge_cases.csv
+++ b/integration_tests/seeds/datasets/redshift/output__redshift_edge_cases.csv
@@ -1,0 +1,3 @@
+customer_id,text_with_quotes,text_with_backslash,is_flagged
+1,"say ""hello""",path\to\file,true
+2,plain text,normal text,false

--- a/integration_tests/seeds/datasets/seed_schema.yml
+++ b/integration_tests/seeds/datasets/seed_schema.yml
@@ -85,3 +85,11 @@ seeds:
     config:
       column_types:
         ts: "{{ 'datetime' if target.name == 'bigquery' else 'timestamp' }}"
+
+  - name: output__redshift_edge_cases
+    config:
+      column_types:
+        customer_id: "{{ 'string' if target.name == 'bigquery' else 'text' }}"
+        text_with_quotes: "{{ 'string' if target.name == 'bigquery' else 'text' }}"
+        text_with_backslash: "{{ 'string' if target.name == 'bigquery' else 'text' }}"
+        is_flagged: "{{ 'string' if target.name == 'bigquery' else 'text' }}"

--- a/macros/activity_schema/activity/build_json.sql
+++ b/macros/activity_schema/activity/build_json.sql
@@ -36,7 +36,14 @@
     {%- set features = data_types.keys() -%}
     json_parse('{' ||
         {% for feature in features -%}
-        {% if not loop.first -%}', '|| {%- endif -%}'"{{feature}}": "' || decode(cast({{feature}} as {{dbt.type_string()}}), null, '', cast({{feature}} as {{dbt.type_string()}})){% if not loop.last %} ||'"'{% endif %}
+        {%- set dtype = data_types[feature] | lower -%}
+        {% if not loop.first -%}', '|| {%- endif -%}'"{{feature}}": "' ||
+        {%- if 'bool' in dtype -%}
+        case when {{feature}} is true then 'true' when {{feature}} is false then 'false' else '' end
+        {%- else -%}
+        replace(replace(decode(cast({{feature}} as {{dbt.type_string()}}), null, '', cast({{feature}} as {{dbt.type_string()}})), '\\', '\\\\'), '"', '\\"')
+        {%- endif -%}
+        {% if not loop.last %} ||'"'{% endif %}
         {% endfor -%}
     || '"}')
     {%- else -%}


### PR DESCRIPTION
Redshift's string-concatenation JSON builder had two bugs:
- Boolean fields cast to varchar yield `t`/`f`, not `true`/`false`
- Text fields containing `"` or `\` produce invalid JSON

Fix branches on data_types[feature] type: booleans use CASE WHEN IS TRUE/FALSE, text escapes `\` then `"` via replace().

Closes #90